### PR TITLE
Add homepage campaigns section and navbar theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Generated files in `dist/` folder.
 | `/feedback`  | Feedback   | Feedback submission form   |
 | `/blogs`     | BlogList   | List of blog posts         |
 | `/blogs/:id` | BlogDetail | View individual blog post  |
+| `/campaigns` | Campaigns  | List all campaigns |
+| `/campaigns/create` | CreateCampaign | Create a new campaign |
 
 ## 🔄 Environment Variables
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import { ProtectedRoute } from "./components/ProtectedRoute";
 import { Logout } from "./components/auth/logout";
 import {Dashboard} from "./pages/Dashboard";
 import Blogs from "./pages/Blogs";
+import Campaigns from "./pages/Campaigns";
+import CreateCampaign from "./pages/CreateCampaign";
 
 
 
@@ -20,6 +22,8 @@ const App = () => {
   return (
     <Routes>
     <Route path="/" element={<Home />} />
+    <Route path="/campaigns" element={<Campaigns />} />
+    <Route path="/campaigns/create" element={<CreateCampaign />} />
     <Route path="/blog" element={<Blogs />} />
     <Route path="/login" element={<Login/>} />
     <Route path="/signup" element={<SignUp />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,7 +23,14 @@ const App = () => {
     <Routes>
     <Route path="/" element={<Home />} />
     <Route path="/campaigns" element={<Campaigns />} />
-    <Route path="/campaigns/create" element={<CreateCampaign />} />
+    <Route
+      path="/campaigns/create"
+      element={
+        <ProtectedRoute>
+          <CreateCampaign />
+        </ProtectedRoute>
+      }
+    />
     <Route path="/blog" element={<Blogs />} />
     <Route path="/login" element={<Login/>} />
     <Route path="/signup" element={<SignUp />} />

--- a/src/components/CampaignSection.jsx
+++ b/src/components/CampaignSection.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import API from "../utils/axios";
+
+export const CampaignSection = () => {
+  const [campaigns, setCampaigns] = useState([]);
+
+  useEffect(() => {
+    API.get("/campaigns")
+      .then((res) => setCampaigns(res.data.campaigns?.slice(0, 3) || []))
+      .catch(() => setCampaigns([]));
+  }, []);
+
+  return (
+    <section className="bg-white py-16 px-6">
+      <h3 className="text-2xl font-semibold text-center mb-10">Recent Campaigns</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-8 max-w-6xl mx-auto">
+        {campaigns.length === 0 && (
+          <p className="text-gray-500 col-span-full text-center">No campaigns yet.</p>
+        )}
+        {campaigns.map((camp, idx) => (
+          <div key={idx} className="bg-gray-50 rounded shadow hover:shadow-lg p-4">
+            <h4 className="font-bold text-lg">{camp.title}</h4>
+            <p className="mt-2 text-gray-700">{camp.description}</p>
+          </div>
+        ))}
+      </div>
+      <div className="text-center mt-8">
+        <Link to="/campaigns" className="bg-emerald-500 text-white px-6 py-3 rounded hover:bg-emerald-600">
+          View All Campaigns
+        </Link>
+      </div>
+    </section>
+  );
+};

--- a/src/components/CampaignSection.jsx
+++ b/src/components/CampaignSection.jsx
@@ -19,9 +19,21 @@ export const CampaignSection = () => {
           <p className="text-gray-500 col-span-full text-center">No campaigns yet.</p>
         )}
         {campaigns.map((camp, idx) => (
-          <div key={idx} className="bg-gray-50 rounded shadow hover:shadow-lg p-4">
-            <h4 className="font-bold text-lg">{camp.title}</h4>
-            <p className="mt-2 text-gray-700">{camp.description}</p>
+          <div key={idx} className="bg-gray-50 rounded shadow hover:shadow-lg overflow-hidden">
+            {camp.image && (
+              <img
+                src={camp.image}
+                alt={camp.title}
+                className="w-full h-40 object-cover"
+              />
+            )}
+            <div className="p-4">
+              <h4 className="font-bold text-lg">{camp.title}</h4>
+              <p className="text-sm text-gray-500 mt-1">
+                {new Date(camp.startTime).toLocaleDateString()} - {new Date(camp.endTime).toLocaleDateString()}
+              </p>
+              <p className="mt-2 text-gray-700">{camp.description}</p>
+            </div>
           </div>
         ))}
       </div>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 // Navbar.jsx
 import { useEffect, useState, useRef } from "react";
-import { Link,useLocation  } from "react-router-dom";
+import { Link } from "react-router-dom";
 import API from "../utils/axios";
 
 export const Navbar = () => {
@@ -8,7 +8,6 @@ export const Navbar = () => {
   const [user, setUser] = useState(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef();
-  const location = useLocation();
 
   useEffect(() => {
     API.get("/user/data", { withCredentials: true })
@@ -31,22 +30,22 @@ export const Navbar = () => {
   }, []);
 
   return (
-    <header className="bg-slate-900 text-white shadow-md sticky top-0 z-50">
+    <header className="bg-emerald-600 text-white shadow-md sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
         <h1 className="text-xl font-bold">CyberShield</h1>
         <nav className="space-x-6 hidden md:flex">
-          <Link to="/" className="hover:text-emerald-400">Home</Link>
-          <Link to="/campaigns" className="hover:text-emerald-400">Campaigns</Link>
-          <Link to="/blog" className="hover:text-emerald-400">Blog</Link>
-          <Link to="/resources" className="hover:text-emerald-400">Resources</Link>
-          <Link to="/helpline" className="hover:text-emerald-400">Helpline</Link>
+          <Link to="/" className="hover:text-white/80">Home</Link>
+          <Link to="/campaigns" className="hover:text-white/80">Campaigns</Link>
+          <Link to="/blog" className="hover:text-white/80">Blog</Link>
+          <Link to="/resources" className="hover:text-white/80">Resources</Link>
+          <Link to="/helpline" className="hover:text-white/80">Helpline</Link>
         </nav>
         <div className="space-x-3 relative" ref={dropdownRef}>
           {isLoggedIn ? (
             <div className="relative">
               <button
                 onClick={() => setDropdownOpen(!dropdownOpen)}
-                className="text-white px-4 py-2 rounded hover:bg-slate-800"
+                className="text-white px-4 py-2 rounded hover:bg-emerald-700"
               >
                 {user?.name || "User"} ▾
               </button>
@@ -60,7 +59,12 @@ export const Navbar = () => {
               )}
             </div>
           ) : (
-            <Link to="/login" className="bg-emerald-500 hover:bg-emerald-600 px-4 py-2 rounded text-white">Login</Link>
+            <Link
+              to="/login"
+              className="bg-white text-emerald-700 border border-emerald-700 px-4 py-2 rounded hover:bg-emerald-50"
+            >
+              Login
+            </Link>
           )}
           {/* <Link to="/signup">
             <button className="bg-emerald-500 hover:bg-emerald-600 px-4 py-2 rounded text-white">Get Started</button>

--- a/src/components/auth/Login.jsx
+++ b/src/components/auth/Login.jsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { AuthLayout } from "./AuthLayout";
 import { Navbar } from "../Navbar";
 import API from "../../utils/axios";

--- a/src/components/auth/SignUp.jsx
+++ b/src/components/auth/SignUp.jsx
@@ -9,13 +9,9 @@ export const SignUp = () => {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setError("");
-    setSuccess("");
     try {
       await axios.post("http://localhost:3000/api/auth/register", {
         name,

--- a/src/components/auth/logout.jsx
+++ b/src/components/auth/logout.jsx
@@ -13,6 +13,7 @@ export const Logout = () => {
         await axios.post("http://localhost:3000/api/auth/logout", {}, { withCredentials: true });
         toast.success("Logged out successfully");
       } catch (err) {
+        console.error(err);
         toast.error("Logout failed");
       } finally {
         navigate("/login");

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -31,9 +31,29 @@ const Campaigns = () => {
             <p className="text-gray-500">No campaigns yet.</p>
           )}
           {campaigns.map((camp, idx) => (
-            <div key={idx} className="border rounded p-4 bg-white">
-              <h3 className="font-semibold text-lg">{camp.title}</h3>
-              <p className="text-gray-700 mt-2">{camp.description}</p>
+            <div key={idx} className="border rounded overflow-hidden bg-white">
+              {camp.image && (
+                <img
+                  src={camp.image}
+                  alt={camp.title}
+                  className="w-full h-48 object-cover"
+                />
+              )}
+              <div className="p-4">
+                <h3 className="font-semibold text-lg">{camp.title}</h3>
+                <p className="text-sm text-gray-500 mt-1">
+                  Created by {camp.createdBy?.name || camp.createdBy} on{' '}
+                  {new Date(camp.createdAt).toLocaleString()}
+                </p>
+                <p className="text-sm text-gray-500">
+                  {new Date(camp.startTime).toLocaleString()} -{' '}
+                  {new Date(camp.endTime).toLocaleString()}
+                  {new Date(camp.endTime) < new Date() && (
+                    <span className="ml-2 text-red-600 font-semibold">Expired</span>
+                  )}
+                </p>
+                <p className="text-gray-700 mt-2">{camp.description}</p>
+              </div>
             </div>
           ))}
         </div>

--- a/src/pages/Campaigns.jsx
+++ b/src/pages/Campaigns.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+import { Navbar } from "../components/Navbar";
+import { Link } from "react-router-dom";
+import API from "../utils/axios";
+
+const Campaigns = () => {
+  const [campaigns, setCampaigns] = useState([]);
+
+  useEffect(() => {
+    // Fetch existing campaigns if the API is available
+    API.get("/campaigns")
+      .then((res) => setCampaigns(res.data.campaigns || []))
+      .catch(() => setCampaigns([]));
+  }, []);
+
+  return (
+    <>
+      <Navbar />
+      <div className="max-w-5xl mx-auto p-6">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-2xl font-bold">Campaigns</h2>
+          <Link
+            to="/campaigns/create"
+            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          >
+            Create Campaign
+          </Link>
+        </div>
+        <div className="grid gap-4">
+          {campaigns.length === 0 && (
+            <p className="text-gray-500">No campaigns yet.</p>
+          )}
+          {campaigns.map((camp, idx) => (
+            <div key={idx} className="border rounded p-4 bg-white">
+              <h3 className="font-semibold text-lg">{camp.title}</h3>
+              <p className="text-gray-700 mt-2">{camp.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Campaigns;

--- a/src/pages/CreateCampaign.jsx
+++ b/src/pages/CreateCampaign.jsx
@@ -7,11 +7,14 @@ import { ToastContainer, toast } from "react-toastify";
 const CreateCampaign = () => {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
+  const [image, setImage] = useState("");
+  const [startTime, setStartTime] = useState("");
+  const [endTime, setEndTime] = useState("");
   const navigate = useNavigate();
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    API.post("/campaigns", { title, description })
+    API.post("/campaigns", { title, description, image, startTime, endTime })
       .then(() => {
         toast.success("Campaign created!");
         navigate("/campaigns");
@@ -33,17 +36,45 @@ const CreateCampaign = () => {
             onChange={(e) => setTitle(e.target.value)}
             required
           />
-          <textarea
-            placeholder="Campaign description"
+        <textarea
+          placeholder="Campaign description"
+          className="w-full px-3 py-2 border rounded"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Image URL"
+          className="w-full px-3 py-2 border rounded"
+          value={image}
+          onChange={(e) => setImage(e.target.value)}
+          required
+        />
+        <label className="block">
+          <span className="text-sm">Start Date &amp; Time</span>
+          <input
+            type="datetime-local"
             className="w-full px-3 py-2 border rounded"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            value={startTime}
+            onChange={(e) => setStartTime(e.target.value)}
             required
           />
-          <button
-            type="submit"
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-          >
+        </label>
+        <label className="block">
+          <span className="text-sm">End Date &amp; Time</span>
+          <input
+            type="datetime-local"
+            className="w-full px-3 py-2 border rounded"
+            value={endTime}
+            onChange={(e) => setEndTime(e.target.value)}
+            required
+          />
+        </label>
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
             Submit
           </button>
         </form>

--- a/src/pages/CreateCampaign.jsx
+++ b/src/pages/CreateCampaign.jsx
@@ -1,0 +1,67 @@
+import React, { useState } from "react";
+import { Navbar } from "../components/Navbar";
+import { useNavigate } from "react-router-dom";
+import API from "../utils/axios";
+import { ToastContainer, toast } from "react-toastify";
+
+const CreateCampaign = () => {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    API.post("/campaigns", { title, description })
+      .then(() => {
+        toast.success("Campaign created!");
+        navigate("/campaigns");
+      })
+      .catch(() => toast.error("Failed to create campaign"));
+  };
+
+  return (
+    <>
+      <Navbar />
+      <div className="max-w-3xl mx-auto p-6">
+        <h2 className="text-2xl font-bold mb-4">Create Campaign</h2>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <input
+            type="text"
+            placeholder="Campaign title"
+            className="w-full px-3 py-2 border rounded"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
+          <textarea
+            placeholder="Campaign description"
+            className="w-full px-3 py-2 border rounded"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            required
+          />
+          <button
+            type="submit"
+            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          >
+            Submit
+          </button>
+        </form>
+      </div>
+      <ToastContainer
+        position="bottom-right"
+        autoClose={5000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick={false}
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme="light"
+      />
+    </>
+  );
+};
+
+export default CreateCampaign;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,15 +3,17 @@ import { Navbar } from "../components/Navbar";
 import { HeroSection } from "../components/HeroSection";
 import { Features } from "../components/Features";
 import { BlogSection } from "../components/BlogSection";
+import { CampaignSection } from "../components/CampaignSection";
 import { Footer } from "../components/Footer";
 
 const Home = () => {
   return (
-    <div className="font-sans text-gray-800">
+    <div className="font-sans text-gray-800 bg-gradient-to-b from-emerald-50 via-white to-white">
       <Navbar />
       <HeroSection />
       <Features />
       <BlogSection />
+      <CampaignSection />
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- redesign `Navbar` with a friendlier emerald color theme
- add a reusable `CampaignSection` component
- include campaigns on the homepage with a modern gradient background
- clean up unused variables in auth components

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f6042f8ac832d820b9aa3d60333bb