### PR TITLE
Add authenticated user dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import { ResetPassword } from "./components/auth/ResetPassword";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { Logout } from "./components/auth/logout";
 import { Dashboard } from "./pages/Dashboard";
+import { UserDetails } from "./pages/UserDetails";
 import Blogs from "./pages/Blogs";
 import Campaigns from "./pages/Campaigns";
 import CreateCampaign from "./pages/CreateCampaign";
@@ -48,6 +49,14 @@ const App = () => {
           element={
             <ProtectedRoute>
               <Dashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/dashboard/details"
+          element={
+            <ProtectedRoute>
+              <UserDetails />
             </ProtectedRoute>
           }
         />

--- a/src/components/dashboard/DashboardSidebar.jsx
+++ b/src/components/dashboard/DashboardSidebar.jsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+
+export const DashboardSidebar = ({ user }) => (
+  <aside className="bg-gray-100 w-60 p-4 space-y-4">
+    <div>
+      <p className="font-semibold">{user?.name}</p>
+      <p className="text-sm text-gray-600">{user?.email}</p>
+    </div>
+    <nav className="space-y-2">
+      <Link to="/dashboard" className="block hover:underline">
+        Overview
+      </Link>
+      <Link to="/campaigns/create" className="block hover:underline">
+        Post Campaign
+      </Link>
+      <Link to="/dashboard/details" className="block hover:underline">
+        User Details
+      </Link>
+    </nav>
+  </aside>
+);

--- a/src/pages/CreateCampaign.jsx
+++ b/src/pages/CreateCampaign.jsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Navbar } from "../components/Navbar";
 import { Footer } from "../components/Footer";
 import { useNavigate } from "react-router-dom";
 import API from "../utils/axios";
 import { ToastContainer, toast } from "react-toastify";
+import { DashboardSidebar } from "../components/dashboard/DashboardSidebar";
 
 const CreateCampaign = () => {
   const [title, setTitle] = useState("");
@@ -11,7 +12,14 @@ const CreateCampaign = () => {
   const [image, setImage] = useState("");
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
+  const [user, setUser] = useState(null);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    API.get("/user/data")
+      .then((res) => setUser(res.data.user))
+      .catch(() => setUser(null));
+  }, []);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -24,11 +32,13 @@ const CreateCampaign = () => {
   };
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col font-sans">
       <Navbar />
-      <main className="flex-grow max-w-3xl mx-auto p-6">
-        <h2 className="text-2xl font-bold mb-4">Create Campaign</h2>
-        <form className="space-y-4" onSubmit={handleSubmit}>
+      <div className="flex flex-grow">
+        <DashboardSidebar user={user} />
+        <main className="flex-grow max-w-3xl mx-auto p-6">
+          <h2 className="text-2xl font-bold mb-4">Create Campaign</h2>
+          <form className="space-y-4" onSubmit={handleSubmit}>
           <input
             type="text"
             placeholder="Campaign title"
@@ -78,8 +88,9 @@ const CreateCampaign = () => {
         >
             Submit
           </button>
-        </form>
-      </main>
+          </form>
+        </main>
+      </div>
       <ToastContainer
         position="bottom-right"
         autoClose={5000}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,12 +1,85 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Navbar } from "../components/Navbar";
 import { Footer } from "../components/Footer";
+import API from "../utils/axios";
 
 export const Dashboard = () => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [campaigns, setCampaigns] = useState([]);
+  const [campLoading, setCampLoading] = useState(true);
+
+  useEffect(() => {
+    API.get("/user/data")
+      .then((res) => {
+        setUser(res.data.user);
+      })
+      .catch(() => {
+        setUser(null);
+      })
+      .finally(() => setLoading(false));
+
+    API.get("/user/campaigns")
+      .then((res) => setCampaigns(res.data.campaigns || []))
+      .catch(() => setCampaigns([]))
+      .finally(() => setCampLoading(false));
+  }, []);
+
   return (
     <div className="min-h-screen flex flex-col font-sans text-gray-800">
       <Navbar />
-      <main className="flex-grow p-6">Dashboard content</main>
+      <main className="flex-grow p-6 space-y-6">
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          <div className="space-y-2">
+            <h2 className="text-2xl font-bold">Welcome {user?.name}</h2>
+            <p className="text-gray-700">Email: {user?.email}</p>
+            {user?.isBusiness && (
+              <p className="text-gray-700">Business: {user.businessName}</p>
+            )}
+          </div>
+        )}
+
+        <section>
+          <h3 className="text-xl font-semibold mb-4">Your Campaigns</h3>
+          {campLoading ? (
+            <p>Loading...</p>
+          ) : campaigns.length === 0 ? (
+            <p className="text-gray-500">No campaigns created yet.</p>
+          ) : (
+            <div className="grid gap-4">
+              {campaigns.map((camp, idx) => (
+                <div
+                  key={idx}
+                  className="border rounded overflow-hidden bg-white"
+                >
+                  {camp.image && (
+                    <img
+                      src={camp.image}
+                      alt={camp.title}
+                      className="w-full h-48 object-cover"
+                    />
+                  )}
+                  <div className="p-4">
+                    <h3 className="font-semibold text-lg">{camp.title}</h3>
+                    <p className="text-sm text-gray-500 mt-1">
+                      {new Date(camp.startTime).toLocaleString()} -{' '}
+                      {new Date(camp.endTime).toLocaleString()}
+                      {new Date(camp.endTime) < new Date() && (
+                        <span className="ml-2 text-red-600 font-semibold">
+                          Expired
+                        </span>
+                      )}
+                    </p>
+                    <p className="text-gray-700 mt-2">{camp.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
       <Footer />
     </div>
   );

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Navbar } from "../components/Navbar";
 import { Footer } from "../components/Footer";
+import { DashboardSidebar } from "../components/dashboard/DashboardSidebar";
 import API from "../utils/axios";
 
 export const Dashboard = () => {
@@ -28,12 +29,14 @@ export const Dashboard = () => {
   return (
     <div className="min-h-screen flex flex-col font-sans text-gray-800">
       <Navbar />
-      <main className="flex-grow p-6 space-y-6">
-        {loading ? (
-          <p>Loading...</p>
-        ) : (
-          <div className="space-y-2">
-            <h2 className="text-2xl font-bold">Welcome {user?.name}</h2>
+      <div className="flex flex-grow">
+        <DashboardSidebar user={user} />
+        <main className="flex-grow p-6 space-y-6">
+          {loading ? (
+            <p>Loading...</p>
+          ) : (
+            <div className="space-y-2">
+              <h2 className="text-2xl font-bold">Welcome {user?.name}</h2>
             <p className="text-gray-700">Email: {user?.email}</p>
             {user?.isBusiness && (
               <p className="text-gray-700">Business: {user.businessName}</p>
@@ -79,7 +82,8 @@ export const Dashboard = () => {
             </div>
           )}
         </section>
-      </main>
+        </main>
+      </div>
       <Footer />
     </div>
   );

--- a/src/pages/UserDetails.jsx
+++ b/src/pages/UserDetails.jsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from "react";
+import { Navbar } from "../components/Navbar";
+import { Footer } from "../components/Footer";
+import { DashboardSidebar } from "../components/dashboard/DashboardSidebar";
+import API from "../utils/axios";
+import { ToastContainer, toast } from "react-toastify";
+
+export const UserDetails = () => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState("");
+  const [businessName, setBusinessName] = useState("");
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+
+  useEffect(() => {
+    API.get("/user/data")
+      .then((res) => {
+        setUser(res.data.user);
+        setName(res.data.user.name);
+        setBusinessName(res.data.user.businessName || "");
+      })
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleUpdateDetails = (e) => {
+    e.preventDefault();
+    API.put("/user/update", { name, businessName })
+      .then(() => toast.success("Details updated"))
+      .catch(() => toast.error("Update failed"));
+  };
+
+  const handleUpdatePassword = (e) => {
+    e.preventDefault();
+    API.put("/user/update-password", { currentPassword, newPassword })
+      .then(() => {
+        toast.success("Password updated");
+        setCurrentPassword("");
+        setNewPassword("");
+      })
+      .catch(() => toast.error("Password update failed"));
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col font-sans text-gray-800">
+      <Navbar />
+      <div className="flex flex-grow">
+        <DashboardSidebar user={user} />
+        <main className="flex-grow p-6 space-y-6">
+          {loading ? (
+            <p>Loading...</p>
+          ) : (
+            <>
+              <form onSubmit={handleUpdateDetails} className="space-y-4 max-w-md">
+                <h2 className="text-xl font-semibold">Edit Details</h2>
+                <input
+                  type="text"
+                  className="w-full border px-3 py-2 rounded"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Name"
+                />
+                {user?.isBusiness && (
+                  <input
+                    type="text"
+                    className="w-full border px-3 py-2 rounded"
+                    value={businessName}
+                    onChange={(e) => setBusinessName(e.target.value)}
+                    placeholder="Business Name"
+                  />
+                )}
+                <button
+                  type="submit"
+                  className="px-4 py-2 bg-emerald-600 text-white rounded"
+                >
+                  Save Changes
+                </button>
+              </form>
+
+              <form onSubmit={handleUpdatePassword} className="space-y-4 max-w-md">
+                <h2 className="text-xl font-semibold">Update Password</h2>
+                <input
+                  type="password"
+                  className="w-full border px-3 py-2 rounded"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  placeholder="Current Password"
+                />
+                <input
+                  type="password"
+                  className="w-full border px-3 py-2 rounded"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  placeholder="New Password"
+                />
+                <button
+                  type="submit"
+                  className="px-4 py-2 bg-emerald-600 text-white rounded"
+                >
+                  Update Password
+                </button>
+              </form>
+            </>
+          )}
+        </main>
+      </div>
+      <ToastContainer position="bottom-right" theme="light" />
+      <Footer />
+    </div>
+  );
+};

--- a/src/pages/UserDetails.jsx
+++ b/src/pages/UserDetails.jsx
@@ -9,16 +9,24 @@ export const UserDetails = () => {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
   const [businessName, setBusinessName] = useState("");
+  const [businessAddress, setBusinessAddress] = useState("");
+  const [businessAbn, setBusinessAbn] = useState("");
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
 
   useEffect(() => {
     API.get("/user/data")
       .then((res) => {
-        setUser(res.data.user);
-        setName(res.data.user.name);
-        setBusinessName(res.data.user.businessName || "");
+        const u = res.data.user;
+        setUser(u);
+        setName(u.name);
+        setEmail(u.email);
+        setBusinessName(u.businessName || "");
+        setBusinessAddress(u.businessAddress || "");
+        setBusinessAbn(u.businessAbn || "");
       })
       .catch(() => setUser(null))
       .finally(() => setLoading(false));
@@ -26,7 +34,13 @@ export const UserDetails = () => {
 
   const handleUpdateDetails = (e) => {
     e.preventDefault();
-    API.put("/user/update", { name, businessName })
+    API.put("/user/update", {
+      name,
+      email,
+      businessName,
+      businessAddress,
+      businessAbn,
+    })
       .then(() => toast.success("Details updated"))
       .catch(() => toast.error("Update failed"));
   };
@@ -38,6 +52,7 @@ export const UserDetails = () => {
         toast.success("Password updated");
         setCurrentPassword("");
         setNewPassword("");
+        setShowPasswordModal(false);
       })
       .catch(() => toast.error("Password update failed"));
   };
@@ -61,14 +76,37 @@ export const UserDetails = () => {
                   onChange={(e) => setName(e.target.value)}
                   placeholder="Name"
                 />
+                <input
+                  type="email"
+                  className="w-full border px-3 py-2 rounded"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="Email"
+                />
                 {user?.isBusiness && (
-                  <input
-                    type="text"
-                    className="w-full border px-3 py-2 rounded"
-                    value={businessName}
-                    onChange={(e) => setBusinessName(e.target.value)}
-                    placeholder="Business Name"
-                  />
+                  <>
+                    <input
+                      type="text"
+                      className="w-full border px-3 py-2 rounded"
+                      value={businessName}
+                      onChange={(e) => setBusinessName(e.target.value)}
+                      placeholder="Business Name"
+                    />
+                    <input
+                      type="text"
+                      className="w-full border px-3 py-2 rounded"
+                      value={businessAddress}
+                      onChange={(e) => setBusinessAddress(e.target.value)}
+                      placeholder="Business Address"
+                    />
+                    <input
+                      type="text"
+                      className="w-full border px-3 py-2 rounded"
+                      value={businessAbn}
+                      onChange={(e) => setBusinessAbn(e.target.value)}
+                      placeholder="ABN"
+                    />
+                  </>
                 )}
                 <button
                   type="submit"
@@ -77,34 +115,55 @@ export const UserDetails = () => {
                   Save Changes
                 </button>
               </form>
-
-              <form onSubmit={handleUpdatePassword} className="space-y-4 max-w-md">
-                <h2 className="text-xl font-semibold">Update Password</h2>
-                <input
-                  type="password"
-                  className="w-full border px-3 py-2 rounded"
-                  value={currentPassword}
-                  onChange={(e) => setCurrentPassword(e.target.value)}
-                  placeholder="Current Password"
-                />
-                <input
-                  type="password"
-                  className="w-full border px-3 py-2 rounded"
-                  value={newPassword}
-                  onChange={(e) => setNewPassword(e.target.value)}
-                  placeholder="New Password"
-                />
-                <button
-                  type="submit"
-                  className="px-4 py-2 bg-emerald-600 text-white rounded"
-                >
-                  Update Password
-                </button>
-              </form>
+              <button
+                type="button"
+                onClick={() => setShowPasswordModal(true)}
+                className="px-4 py-2 bg-emerald-600 text-white rounded"
+              >
+                Change Password
+              </button>
             </>
           )}
         </main>
       </div>
+      {showPasswordModal && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <div className="bg-white p-6 rounded shadow-lg w-80 space-y-4">
+            <h2 className="text-xl font-semibold">Update Password</h2>
+            <form onSubmit={handleUpdatePassword} className="space-y-4">
+              <input
+                type="password"
+                className="w-full border px-3 py-2 rounded"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                placeholder="Current Password"
+              />
+              <input
+                type="password"
+                className="w-full border px-3 py-2 rounded"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                placeholder="New Password"
+              />
+              <div className="flex justify-end space-x-2">
+                <button
+                  type="button"
+                  onClick={() => setShowPasswordModal(false)}
+                  className="px-4 py-2 border rounded"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="px-4 py-2 bg-emerald-600 text-white rounded"
+                >
+                  Update
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
       <ToastContainer position="bottom-right" theme="light" />
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- fetch user data on the dashboard page
- show name, email and business info when available
- display a list of the user's campaigns

## Testing
- `npm run lint` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_684838b3d9e8832d9319ab0a1f9c0fde